### PR TITLE
Fix sqlite datetime handling for hot torrents

### DIFF
--- a/src/torrents.nim
+++ b/src/torrents.nim
@@ -63,7 +63,7 @@ proc hotTorrents*(page: string): seq[Torrent] =
   let torrents = db.getAllRows(sql"""
   SELECT name, source, uploaded_at, canonical_url, magnet_url, size, seeders, leechers
   FROM torrents
-  WHERE uploaded_at BETWEEN datetime('now', '-6 days') AND datetime('now', 'localtime')
+  WHERE datetime(uploaded_at) BETWEEN datetime('now', '-6 days') AND datetime('now')
   ORDER BY seeders DESC
   LIMIT ?
   OFFSET ?;


### PR DESCRIPTION
The hot torrents endpoint doesn't work at all on my system (I'm not sure how it's working on anyone's system unless DateTime is formatting without the T separator).

uploaded_at contains the ISO-8601 'T' separator, but sqlite uses string comparisons to filter the desired range. It's necessary to strip the 'T' by passing uploaded_at through the datetime function. Unfortunately this loses the use of the index. Alternatives might be to construct the datetimes manually to include the 'T' to match the uploaded_at field, or to insert uploaded_at as UTC to match sqlite's native datetime representation.

sqlite's default datetime zone is UTC, so the upper bound should not be modified to the localtime.